### PR TITLE
In navbar on scroll Make background white without opacity

### DIFF
--- a/src/app/components/header/styles.tsx
+++ b/src/app/components/header/styles.tsx
@@ -31,9 +31,8 @@ const MainHeader = styled.div<Props>`
     props.isScrollPage &&
     css`
       padding: 16px 0;
-      background: rgba(255, 255, 255, 0.65);
+      background: #fff;
       box-shadow: 0px 2px 12px 0px rgba(0, 0, 0, 0.06);
-      backdrop-filter: blur(20px);
     `};
 `;
 const Maindiv = styled.div`


### PR DESCRIPTION
### What this does
In navbar make background white without opacity when page is scrolled 

### Implementation
In navbar make background white without opacity when page is scrolled 

### Testing
![image](https://github.com/devmakasana/aiyyna-nextjs/assets/135232467/bc9fb0ec-2a4d-4847-9dd5-b3a270c9fad4)

